### PR TITLE
fix for bug: connection objects and their associated buffers don't ge…

### DIFF
--- a/Release/src/http/listener/http_server_asio.cpp
+++ b/Release/src/http/listener/http_server_asio.cpp
@@ -258,6 +258,11 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request._reply_if_not_already(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
+            return;
         }
     }
     else
@@ -285,6 +290,10 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request.reply(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
 
@@ -300,6 +309,10 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request.reply(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
 
@@ -313,6 +326,10 @@ void connection::handle_http_line(const boost::system::error_code& ec)
             m_request.reply(status_codes::BadRequest, e.what());
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
 
@@ -358,6 +375,10 @@ void connection::handle_headers()
             m_request.reply(status_codes::BadRequest);
             m_close = true;
             do_response(true);
+            if (--m_refs == 0)
+            {
+                delete this;
+            }
             return;
         }
     }


### PR DESCRIPTION
…t released in some cases.

In several places when errors happen during the request sequence the reference on the connection object is not getting decremented.
This causes memory leaking of connection objects and their associated boost asio buffers.
This is most serious at location in handle_http_line() where while waiting for the next HTTP request from peer, the server can get a connection reset by peer quite frequently resulting in significant memory bloating.
Following elaborates the leaking sequence:
On certain request error conditions, the current code is doing m_close=true followed by a do_response() and returns from the request sequence.
But before ending the request sequence the code must decrement the reference count on connection object initialized to 1 at construction.
do_response() begins a response sequence after incrementing the reference count which is decremented in finish_request_response.
But the reference count from construction remains and the connection object never gets released.
So the fix is to decrement the reference count before returning from the request sequence.